### PR TITLE
Bug fix: Make edits to ideas appear in idea list

### DIFF
--- a/BlogIdeaList-SwiftUI.xcodeproj/project.pbxproj
+++ b/BlogIdeaList-SwiftUI.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		936444842310DD65009CBE78 /* BlogIdeaCellView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 936444832310DD65009CBE78 /* BlogIdeaCellView.swift */; };
 		CE44E4DB22F303FF00BE2EDD /* EditView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE44E4DA22F303FF00BE2EDD /* EditView.swift */; };
 		CE676F3D22F0B74F006141D1 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE676F3C22F0B74F006141D1 /* AppDelegate.swift */; };
 		CE676F3F22F0B74F006141D1 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE676F3E22F0B74F006141D1 /* SceneDelegate.swift */; };
@@ -19,6 +20,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		936444832310DD65009CBE78 /* BlogIdeaCellView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlogIdeaCellView.swift; sourceTree = "<group>"; };
 		CE44E4DA22F303FF00BE2EDD /* EditView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditView.swift; sourceTree = "<group>"; };
 		CE676F3922F0B74F006141D1 /* BlogIdeaList-SwiftUI.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "BlogIdeaList-SwiftUI.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		CE676F3C22F0B74F006141D1 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -75,6 +77,7 @@
 				CE676F3C22F0B74F006141D1 /* AppDelegate.swift */,
 				CE676F3E22F0B74F006141D1 /* SceneDelegate.swift */,
 				CE676F4322F0B74F006141D1 /* ContentView.swift */,
+				936444832310DD65009CBE78 /* BlogIdeaCellView.swift */,
 				CE44E4DA22F303FF00BE2EDD /* EditView.swift */,
 				CE676F4522F0B74F006141D1 /* Assets.xcassets */,
 				CE676F4A22F0B74F006141D1 /* LaunchScreen.storyboard */,
@@ -167,6 +170,7 @@
 				CE676F3D22F0B74F006141D1 /* AppDelegate.swift in Sources */,
 				CE44E4DB22F303FF00BE2EDD /* EditView.swift in Sources */,
 				CE676F4222F0B74F006141D1 /* BlogIdeaList_SwiftUI.xcdatamodeld in Sources */,
+				936444842310DD65009CBE78 /* BlogIdeaCellView.swift in Sources */,
 				CE676F4422F0B74F006141D1 /* ContentView.swift in Sources */,
 				CE676F3F22F0B74F006141D1 /* SceneDelegate.swift in Sources */,
 			);

--- a/BlogIdeaList-SwiftUI/BlogIdeaCellView.swift
+++ b/BlogIdeaList-SwiftUI/BlogIdeaCellView.swift
@@ -1,0 +1,31 @@
+//
+//  BlogIdeaCellView.swift
+//  BlogIdeaList-SwiftUI
+//
+//  Created by Grant Grueninger on 8/23/19.
+//  Copyright © 2019 Andrew Bancroft. All rights reserved.
+//
+
+import SwiftUI
+
+struct BlogIdeaCellView: View {
+    @ObservedObject var blogIdea: BlogIdea
+
+    var body: some View {
+        NavigationLink(destination: EditView(blogIdea: blogIdea)) {
+            VStack(alignment: .leading) {
+                Text(blogIdea.ideaTitle ?? "")
+                    .font(.headline)
+                Text(blogIdea.ideaDescription ?? "")
+                    .font(.subheadline)
+            }
+        }
+    }
+}
+
+//struct BlogIdeaCellView_Previews: PreviewProvider {
+//
+//    static var previews: some View {
+//        BlogIdeaCellView()
+//    }
+//}

--- a/BlogIdeaList-SwiftUI/ContentView.swift
+++ b/BlogIdeaList-SwiftUI/ContentView.swift
@@ -70,14 +70,7 @@ struct ContentView: View {
 
                 Section(header: Text("Blog Ideas")) {
                     ForEach(self.blogIdeas) { blogIdea in
-                        NavigationLink(destination: EditView(blogIdea: blogIdea)) {
-                            VStack(alignment: .leading) {
-                                Text(blogIdea.ideaTitle ?? "")
-                                    .font(.headline)
-                                Text(blogIdea.ideaDescription ?? "")
-                                    .font(.subheadline)
-                            }
-                        }
+                        BlogIdeaCellView(blogIdea: blogIdea)
                     }
                     .onDelete { (indexSet) in // Delete gets triggered by swiping left on a row
                         // ❇️ Gets the BlogIdea instance out of the blogIdeas array

--- a/BlogIdeaList-SwiftUI/Core Data/BlogIdea.swift
+++ b/BlogIdeaList-SwiftUI/Core Data/BlogIdea.swift
@@ -28,4 +28,12 @@ extension BlogIdea {
           
         return request
     }
+
+    /// Compensate for probable bug in Xcode 11 beta 6; NSManagedObject won't call `objectWillChange.send()`,
+    /// so we do..
+    override public func willChangeValue(forKey key: String) {
+        self.objectWillChange.send()
+        super.willChangeValue(forKey: key)
+    }
+
 }

--- a/BlogIdeaList-SwiftUI/EditView.swift
+++ b/BlogIdeaList-SwiftUI/EditView.swift
@@ -19,7 +19,7 @@ struct EditView: View {
     // ℹ️ This is used to "go back" when 'Save' is tapped
     @Environment(\.presentationMode) var presentationMode
 
-    var blogIdea: BlogIdea
+    @ObservedObject var blogIdea: BlogIdea
     
     // ℹ️ Temporary in-memory storage for updating the title and description values of a Blog Idea
     @State var updatedIdeaTitle: String = ""


### PR DESCRIPTION
- Identify blogIdea as an "@ObservedObject" on views.
- Split out list rows into BlogIdeaCellView so that blogIdea can be identified as an "@ObservedObject", and therefore invalidate the view when changed.
- Hack in override in BlogIdea class to call objectWillChange when willChangeValue is called to notify SwiftUI of changes so that it will invalidate/redraw affected views.